### PR TITLE
Add call-to-action for users to contribute translations

### DIFF
--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2023-12-15T03:24:32.805Z\n"
+"POT-Creation-Date: 2023-12-15T08:41:45.152Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -555,6 +555,10 @@ msgstr ""
 
 #: /views/index.handlebars
 msgid "Swedish"
+msgstr ""
+
+#: /views/index.handlebars
+msgid "Missing a language? <a href=\"https://weblate.pxls.space/engage/pxls-space/\" target=\"_blank\">Get involved.</a>"
 msgstr ""
 
 #: /views/index.handlebars

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -397,6 +397,9 @@
                                 <option value="bg" selected>{{{i18n 'Bulgarian'}}}</option>
                                 <option value="sv" selected>{{{i18n 'Swedish'}}}</option>
                             </select>
+                            <span class="label-text">
+                                <i class="fas fa-info-circle"></i> {{{i18n 'Missing a language? <a href="https://weblate.pxls.space/engage/pxls-space/" target="_blank">Get involved.</a>'}}}
+                            </span>
                         </label>
                     </div>
                     <div data-keywords="{{{i18n 'themes;look;stylesheets;visuals'}}}">


### PR DESCRIPTION
Introduces a small call-to-action (CTA) below the language override selector to encourage user contributions for translations.

Changes have been verified without backend connectivity.