### PR TITLE
Fix template visibility flicker

### DIFF
--- a/public/include/query.js
+++ b/public/include/query.js
@@ -130,7 +130,20 @@ module.exports.query = (function() {
     },
     update: function() {
       const s = self.getStr();
-      if (location.replace) {
+
+      // NOTE ([  ]): This function fires a url update event, causing the
+      // template to update itself if it was changed. This is *bad* because it
+      // is a queued update while hotkey actions bypass the queued delay for
+      // responsiveness. This means that when a template is toggled on, it
+      // will be toggled on *again* by this call 200ms later. If in that
+      // window the template is turned off, this will not fire a queued update
+      // and so the old queued update turns it back on without interaction.
+      //
+      // TL;DR: This doesn't work but I'm leaving to code here to explain *why.*
+      // A proper fix probably involves fixing this entire mess of:
+      // input, to url, to event, to url, to display, etc.
+      const locationReplaceDisabled = true;
+      if (location.replace && !locationReplaceDisabled) {
         // NOTE ([  ]): this seems to not push to the back button or history UI,
         // *but not on Firefox* at time of writing.
         location.replace('#' + s);

--- a/public/include/template.js
+++ b/public/include/template.js
@@ -400,6 +400,33 @@ module.exports.template = (function() {
 
       self.updateSettings();
 
+      let VKeyPressed = false;
+      // `e` is a key event.
+      // True if v key is the focus of the event.
+      const testForV = (e) => e.key === 'v' || e.key === 'KeyV' || e.key === 'V' || e.which === 86;
+
+      $(window).keydown(function(e) {
+        if (['INPUT', 'TEXTAREA'].includes(e.target.nodeName)) {
+          // prevent inputs from triggering shortcuts
+          return;
+        }
+
+        if (testForV(e)) {
+          if (VKeyPressed) {
+            return;
+          }
+          VKeyPressed = true;
+
+          self._update({ use: !self.options.use });
+        }
+      });
+
+      $(window).keyup(function(e) {
+        if (testForV(e)) {
+          VKeyPressed = false;
+        }
+      });
+
       $(window).keydown(function(evt) {
         if (['INPUT', 'TEXTAREA'].includes(evt.target.nodeName)) {
           // prevent inputs from triggering shortcuts
@@ -432,14 +459,6 @@ module.exports.template = (function() {
           case 34:
             newOpacity = Math.max(0, self.options.opacity - 0.1);
             settings.board.template.opacity.set(newOpacity);
-            break;
-          case 'KeyV':
-          case 86:
-          case 'v':
-          case 'V':
-            self._update({
-              use: !self.options.use
-            });
             break;
         }
       }).on('keyup blur', self.stopDragging);


### PR DESCRIPTION
This does two things:

1. It makes the template visibility toggle work the same as the other overlay toggles. The code for this looks rather ugly to me personally, but I reason that it's better to be consistent so that a later refactor can improve all of this at once.

2. It soft reverts [#671](https://github.com/pxlsspace/Pxls/pull/671) with a lengthy note explaining why that change causes this bug. The summary is that the function used there to update the query string causes a feedback loop to the template under certain conditions on a 200ms delay. This is what caused the template to show up again if it was quickly toggled on and off again.