### PR TITLE
7TV Integration + Move chat history to GET /chat/history

### DIFF
--- a/public/include/chat.js
+++ b/public/include/chat.js
@@ -833,7 +833,7 @@ const chat = (function() {
         if (data.emoteSet7TV) {
           await self.init7TV(data.emoteSet7TV);
           emotes7TV = (self.emoteSet7TV.emotes || []).map(emote => {
-            const emoteUrl = 'https:' + emote.data.host.url + '/2x.webp';
+            const emoteUrl = 'https:' + emote.data.host.url + '/2x.webp?t_' + new Date().getTime();
             return { name: emote.name, emoji: emoteUrl };
           });
         }


### PR DESCRIPTION
This PR adds the client-side component to 7TV emote integration. 7TV emotes are handled after custom emotes. Failed requests to 7TV (if their server is down) will not affect local custom emojis from working.

It also moves chat history from a socket packet to an HTTP endpoint that'll be fetched at the end of `webinit`.