### PR TITLE
fix inconsistent height of chat messages

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1578,7 +1578,7 @@ ul.chat-body li.chat-line:nth-of-type(odd) {
     background: var(--chat-odd-background);
 }
 
-ul.chat-body li.chat-line:not(:last-child):not(:only-of-type) {
+ul.chat-body li.chat-line:not(:only-of-type) {
     padding: 5px 0;
 }
 


### PR DESCRIPTION
fixing the height of chat messages CHANGING upon sending a new one. it was more noticeable with blocked users but it changes regardless of that. just a visual change but it makes things more pleasant