### PR TITLE
Fix timer.js mobile chat cooldown display

### DIFF
--- a/public/include/timer.js
+++ b/public/include/timer.js
@@ -53,8 +53,9 @@ module.exports.timer = (function() {
         self.currentTimer = mins.toString().padStart(2, '0') + ':' + secs.toString().padStart(2, '0');
 
         self.elements.timer_countdown.text(self.currentTimer);
-        self.elements.timer_chat.text(self.currentTimer);
         self.elements.timer_container.show();
+        self.elements.timer_chat.text(self.currentTimer);
+        self.elements.timer_chat.show();
 
         document.title = uiHelper.getTitle();
       } else {
@@ -62,6 +63,7 @@ module.exports.timer = (function() {
 
         self.elements.timer_container.hide();
         self.elements.timer_countdown.text(self.currentTimer);
+        self.elements.timer_chat.hide();
         self.elements.timer_chat.text(self.currentTimer);
 
         // Placeable from 2 are updated at:


### PR DESCRIPTION
Fixed a bug where you could see the timer at 00:00, when having more than 1 peaceable pixel, at the top of the chat menu on small devices.

This is a fix for #45.

Originally reported on [Discord](https://discord.com/channels/298948748317294592/1397015073972551690/1423604118169059388).