### PR TITLE
make pixel place and chat ping sounds configurable

### DIFF
--- a/public/include/chat.js
+++ b/public/include/chat.js
@@ -2543,6 +2543,7 @@ const chat = (function() {
     init: self.init,
     webinit: self.webinit,
     _handleActionClick: self._handleActionClick,
+    pingAudioElem: self.pingAudio,
     clearPings: self.clearPings,
     setCharLimit: self.setCharLimit,
     processMessage: self.processMessage,

--- a/public/include/place.js
+++ b/public/include/place.js
@@ -257,7 +257,8 @@ module.exports.place = (function() {
             $(window).trigger('pxls:ack:place', [data.x, data.y]);
             if (uiHelper.tabHasFocus() && settings.audio.enable.get()) {
               const clone = self.audio.cloneNode(false);
-              clone.volume = parseFloat(settings.audio.alert.volume.get());
+              clone.src = settings.audio.place.src.get() || clone.src;
+              clone.volume = parseFloat(settings.audio.place.volume.get());
               clone.play();
             }
             break;
@@ -381,6 +382,7 @@ module.exports.place = (function() {
       return self.lastPixel;
     },
     toggleReticule: self.toggleReticule,
-    toggleCursor: self.toggleCursor
+    toggleCursor: self.toggleCursor,
+    audioElem: self.audio
   };
 })();

--- a/public/include/settings.js
+++ b/public/include/settings.js
@@ -206,6 +206,8 @@ module.exports.settings = (function() {
     colorBrightness: 'ui.brightness.value',
     'alert.src': 'audio.alert.src',
     'alert.volume': 'audio.alert.volume',
+    'place.src': 'audio.place.src',
+    'place.volume': 'audio.place.volume',
     alert_delay: 'place.alert.delay',
     'chrome-canvas-offset-workaround': 'fix.chrome.offset.enable',
     hide_sensitive: 'lookup.filter.sensitive.enable',
@@ -378,6 +380,10 @@ module.exports.settings = (function() {
       alert: {
         src: setting('audio.alert.src', SettingType.TEXT, '', $('#setting-audio-alert-src')),
         volume: setting('audio.alert.volume', SettingType.RANGE, 1, $('#setting-audio-alert-volume'))
+      },
+      place: {
+        src: setting('audio.place.src', SettingType.TEXT, '', $('#setting-audio-place-src')),
+        volume: setting('audio.place.volume', SettingType.RANGE, 1, $('#setting-audio-place-volume'))
       }
     },
     board: {

--- a/public/include/settings.js
+++ b/public/include/settings.js
@@ -383,7 +383,7 @@ module.exports.settings = (function() {
       },
       place: {
         src: setting('audio.place.src', SettingType.TEXT, '', $('#setting-audio-place-src')),
-        volume: setting('audio.place.volume', SettingType.RANGE, 1, $('#setting-audio-place-volume'))
+        volume: setting('audio.place.volume', SettingType.RANGE, -1, $('#setting-audio-place-volume'))
       }
     },
     board: {
@@ -503,6 +503,10 @@ module.exports.settings = (function() {
       }
     }
   };
+  // this is so users who previously had alert volume lowered do not get jumpscared if the default value of 100% is too loud
+  if (self.audio.place.volume.get() === -1) {
+    self.audio.place.volume.set(self.audio.alert.volume.get());
+  }
   $(window).on('pxls:panel:closed', (event, panel) => {
     if (panel === 'settings') {
       self.filter.search('');

--- a/public/include/settings.js
+++ b/public/include/settings.js
@@ -217,6 +217,7 @@ module.exports.settings = (function() {
     'chat.text-icons-enabled': 'chat.badges.enable',
     'chat.faction-tags-enabled': 'chat.factiontags.enable',
     'chat.pings-enabled': 'chat.pings.enable',
+    'chat.ping-audio-src': 'chat.pings.audio.src',
     'chat.ping-audio-state': 'chat.pings.audio.when',
     'chat.ping-audio-volume': 'chat.pings.audio.volume',
     'chat.banner-enabled': 'ui.chat.banner.enable',
@@ -473,6 +474,7 @@ module.exports.settings = (function() {
       pings: {
         enable: setting('chat.pings.enable', SettingType.TOGGLE, true, $('#setting-chat-pings-enable')),
         audio: {
+          src: setting('chat.pings.audio.src', SettingType.TEXT, '', $('#setting-chat-pings-audio-src')),
           when: setting('chat.pings.audio.when', SettingType.SELECT, 'off', $('#setting-chat-pings-audio-when')),
           volume: setting('chat.pings.audio.volume', SettingType.RANGE, 0.5, $('#setting-chat-pings-audio-volume'))
         }

--- a/public/include/uiHelper.js
+++ b/public/include/uiHelper.js
@@ -18,6 +18,7 @@ const uiHelper = (function() {
     pixelsAvailable: -1,
     maxStacked: -1,
     _alertUpdateTimer: false,
+    _placeSoundUpdateTimer: false,
     initTitle: '',
     isLoadingBubbleShown: false,
     loadingStates: {},
@@ -35,7 +36,9 @@ const uiHelper = (function() {
       captchaLoadingIcon: $('.captcha-loading-icon'),
       coords: $('#coords-info .coords'),
       lblAlertVolume: $('#lblAlertVolume'),
+      lblPlaceSoundVolume: $('#lblPlaceSoundVolume'),
       btnForceAudioUpdate: $('#btnForceAudioUpdate'),
+      btnForcePlaceSoundAudioUpdate: $('#btnForcePlaceSoundAudioUpdate'),
       themeSelect: $('#setting-ui-theme-index'),
       themeColorMeta: $('meta[name="theme-color"]'),
       txtDiscordName: $('#txtDiscordName'),
@@ -478,6 +481,8 @@ const uiHelper = (function() {
       });
     },
     _initAudio: function() {
+      // [TODO] actually make this whole thing not look as bad eventually
+      // notify
       timer.audioElem.addEventListener('error', err => {
         if (console.warn) console.warn('An error occurred on the audioElem node: %o', err);
       });
@@ -501,9 +506,94 @@ const uiHelper = (function() {
       $('#btnAlertAudioTest').click(() => timer.audioElem.play());
 
       $('#btnAlertReset').click(() => {
-        // TODO confirm with user
-        self.updateAudio('notify.wav');
-        settings.audio.alert.src.reset();
+        modal.show(modal.buildDom(
+          crel('h2', { class: 'modal-title' }, __('Reset Sound')),
+          crel('div',
+            crel('p', __('Are you sure you want to reset the pixel notification sound?')),
+            crel('div', { class: 'buttons' },
+              crel('button', {
+                class: 'dangerous-button text-button',
+                onclick: () => {
+                  self.updateAudio('notify.wav');
+                  settings.audio.alert.src.reset();
+                  modal.closeAll();
+                }
+              }, __('Yes')),
+              crel('button', {
+                class: 'text-button',
+                onclick: () => modal.closeAll()
+              }, __('No'))
+            )
+          )
+        ));
+      });
+      // place
+      place.audioElem.addEventListener('error', err => {
+        if (console.warn) console.warn('An error occurred on the audioElem node: %o', err);
+      });
+
+      settings.audio.place.src.listen(function(url) {
+        if (self._placeSoundUpdateTimer !== false) clearTimeout(self._placeSoundUpdateTimer);
+        self._placeSoundUpdateTimer = setTimeout(function(url) {
+          self.updateAudio(url, 'place');
+          self._placeSoundUpdateTimer = false;
+        }, 250, url);
+      });
+      self.elements.btnForcePlaceSoundAudioUpdate.click(() => settings.audio.place.src.set(settings.audio.place.src.get()));
+
+      settings.audio.place.volume.listen(function(value) {
+        const parsed = parseFloat(value);
+        const volume = isNaN(parsed) ? 1 : parsed;
+        self.elements.lblPlaceSoundVolume.text(`${volume * 100 >> 0}%`);
+        place.audioElem.volume = volume;
+      });
+
+      $('#btnPlaceAudioTest').click(() => place.audioElem.play());
+
+      $('#btnAlertReset').click(() => {
+        modal.show(modal.buildDom(
+          crel('h2', { class: 'modal-title' }, __('Reset Sound')),
+          crel('div',
+            crel('p', __('Are you sure you want to reset the pixel notification sound?')),
+            crel('div', { class: 'buttons' },
+              crel('button', {
+                class: 'dangerous-button text-button',
+                onclick: () => {
+                  self.updateAudio('place.wav', 'place');
+                  settings.audio.alert.src.reset();
+                  modal.closeAll();
+                }
+              }, __('Yes')),
+              crel('button', {
+                class: 'text-button',
+                onclick: () => modal.closeAll()
+              }, __('No'))
+            )
+          )
+        ));
+      });
+
+      $('#btnPlaceSoundReset').click(() => {
+        modal.show(modal.buildDom(
+          crel('h2', { class: 'modal-title' }, __('Reset Sound')),
+          crel('div',
+            crel('p', __('Are you sure you want to reset the pixel palced sound?')),
+            crel('div', { class: 'buttons' },
+              crel('button', {
+                class: 'dangerous-button text-button',
+                onclick: () => {
+                  self.updateAudio('place.wav', 'place');
+                  settings.audio.place.src.reset();
+                  modal.closeAll();
+                }
+              }, __('Yes')),
+              crel('button', {
+                class: 'text-button',
+                onclick: () => modal.closeAll()
+              }, __('No'))
+            )
+          )
+        ));
       });
     },
     _initAccount: function() {
@@ -710,13 +800,28 @@ const uiHelper = (function() {
         });
       }
     },
-    updateAudio: function(url) {
+    updateAudio: function(url, type = 'notify') {
+      const configurableSounds = {
+        place: {
+          defaultSound: 'place.wav',
+          targetElement: place.audioElem
+        },
+        notify: {
+          defaultSound: 'notify.wav',
+          targetElement: timer.audioElem
+        },
+        chatnotify: {
+          defaultSound: 'chatnotify.wav',
+          targetElement: chat.pingAudioElem
+        }
+      };
       try {
-        if (!url) url = 'notify.wav';
-        timer.audioElem.src = url;
+        if (!Object.keys(configurableSounds).includes(type)) throw new Error(`updateAudio type must be one of: ${Object.keys(configurableSounds).join(', ')}`);
+        if (!url) url = configurableSounds[type].defaultSound;
+        configurableSounds[type].targetElement.src = url;
       } catch (e) {
         modal.showText(__('Failed to update audio src, using default sound.'));
-        timer.audioElem.src = 'notify.wav';
+        configurableSounds[type].targetElement.src = configurableSounds[type].defaultSound;
       }
     },
     updateAvailable: function(count, cause) {

--- a/public/include/uiHelper.js
+++ b/public/include/uiHelper.js
@@ -19,6 +19,7 @@ const uiHelper = (function() {
     maxStacked: -1,
     _alertUpdateTimer: false,
     _placeSoundUpdateTimer: false,
+    _chatPingSoundUpdateTimer: false,
     initTitle: '',
     isLoadingBubbleShown: false,
     loadingStates: {},
@@ -39,6 +40,7 @@ const uiHelper = (function() {
       lblPlaceSoundVolume: $('#lblPlaceSoundVolume'),
       btnForceAudioUpdate: $('#btnForceAudioUpdate'),
       btnForcePlaceSoundAudioUpdate: $('#btnForcePlaceSoundAudioUpdate'),
+      btnForceChatPingAudioUpdate: $('#btnForceChatPingAudioUpdate'),
       themeSelect: $('#setting-ui-theme-index'),
       themeColorMeta: $('meta[name="theme-color"]'),
       txtDiscordName: $('#txtDiscordName'),
@@ -550,17 +552,17 @@ const uiHelper = (function() {
 
       $('#btnPlaceAudioTest').click(() => place.audioElem.play());
 
-      $('#btnAlertReset').click(() => {
+      $('#btnPlaceSoundReset').click(() => {
         modal.show(modal.buildDom(
           crel('h2', { class: 'modal-title' }, __('Reset Sound')),
           crel('div',
-            crel('p', __('Are you sure you want to reset the pixel notification sound?')),
+            crel('p', __('Are you sure you want to reset the pixel place sound?')),
             crel('div', { class: 'buttons' },
               crel('button', {
                 class: 'dangerous-button text-button',
                 onclick: () => {
                   self.updateAudio('place.wav', 'place');
-                  settings.audio.alert.src.reset();
+                  settings.audio.place.src.reset();
                   modal.closeAll();
                 }
               }, __('Yes')),
@@ -572,18 +574,33 @@ const uiHelper = (function() {
           )
         ));
       });
+      // chat ping
+      chat.pingAudioElem.addEventListener('error', err => {
+        if (console.warn) console.warn('An error occurred on the audioElem node: %o', err);
+      });
 
-      $('#btnPlaceSoundReset').click(() => {
+      settings.chat.pings.audio.src.listen(function(url) {
+        if (self._chatPingSoundUpdateTimer !== false) clearTimeout(self._chatPingSoundUpdateTimer);
+        self._chatPingSoundUpdateTimer = setTimeout(function(url) {
+          self.updateAudio(url, 'chatnotify');
+          self._chatPingSoundUpdateTimer = false;
+        }, 250, url);
+      });
+      self.elements.btnForcePlaceSoundAudioUpdate.click(() => settings.chat.pings.audio.src.set(settings.chat.pings.audio.src.get()));
+
+      $('#btnChatPingAudioTest').click(() => chat.pingAudioElem.play());
+
+      $('#btnChatPingSrcReset').click(() => {
         modal.show(modal.buildDom(
           crel('h2', { class: 'modal-title' }, __('Reset Sound')),
           crel('div',
-            crel('p', __('Are you sure you want to reset the pixel palced sound?')),
+            crel('p', __('Are you sure you want to reset the chat ping sound?')),
             crel('div', { class: 'buttons' },
               crel('button', {
                 class: 'dangerous-button text-button',
                 onclick: () => {
-                  self.updateAudio('place.wav', 'place');
-                  settings.audio.place.src.reset();
+                  self.updateAudio('chatnotify.wav', 'chatnotify');
+                  settings.chat.pings.audio.src.reset();
                   modal.closeAll();
                 }
               }, __('Yes')),

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -826,6 +826,27 @@
                         </label>
                     </div>
                 </section>
+                <section data-keywords="{{{i18n 'place sound;pixel placed'}}}">
+                    <h4>{{{i18n 'Pixel Placed Sound'}}}</h4>
+                    <div data-keywords="{{{i18n 'place sound;place sound url;place sound source;pixel placed sound'}}}">
+                        <label class="input-group">
+                            <span class="label-text">{{{i18n 'Pixel Placed Sound URL:'}}}</span>
+                            <input class="fullwidth" type="text" placeholder="place.wav" id="setting-audio-place-src">
+                        </label>
+                        <div class="button-bar">
+                            <button class="text-button" id="btnForcePlaceSoundAudioUpdate">{{{i18n 'Update'}}}</button>
+                            <button class="text-button" id="btnPlaceAudioTest">{{{i18n 'Test'}}}</button>
+                            <button class="text-button" id="btnPlaceSoundReset">{{{i18n 'Reset'}}}</button>
+                        </div>
+                    </div>
+                    <div data-keywords="{{{i18n 'sound level;audio level;mute audio;mute sound'}}}">
+                        <label class="input-group">
+                            <span class="label-text">{{{i18n 'Volume:'}}}</span>
+                            <input type="range" id="setting-audio-place-volume" min=0 max=1 step=".01" value="1">
+                            <span class="range-text-value" id="lblPlaceSoundVolume">100%</span>
+                        </label>
+                    </div>
+                </section>
                 <section data-keywords="{{{i18n 'chat mentions;chat pings;chat sound'}}}">
                     <h4>{{{i18n 'Chat Pings'}}}</h4>
                     <div data-keywords="enable mentions">

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -857,6 +857,15 @@
                     </div>
                     <div data-keywords="{{{i18n 'mention sound'}}}">
                         <label class="input-group">
+                            <span class="label-text">{{{i18n 'Ping Sound URL:'}}}</span>
+                            <input class="fullwidth" type="text" placeholder="chatnotify.wav" id="setting-chat-pings-audio-src">
+                        </label>
+                        <div class="button-bar">
+                            <button class="text-button" id="btnForceChatPingAudioUpdate">{{{i18n 'Update'}}}</button>
+                            <button class="text-button" id="btnChatPingAudioTest">{{{i18n 'Test'}}}</button>
+                            <button class="text-button" id="btnChatPingSrcReset">{{{i18n 'Reset'}}}</button>
+                        </div>
+                        <label class="input-group">
                             <span class="label-text">{{{i18n 'Play sound on ping:'}}} </span>
                             <select id="setting-chat-pings-audio-when">
                                 <option value="off">{{{i18n 'Off'}}}</option>


### PR DESCRIPTION
adds settings sections for setting the audio source url for the pixel place sound and chat ping sound, and a confirmation modal for resetting any of the audio source urls. also added a separate volume slider (for literally no reason) to the pixel place sound which defaults to whatever the alert sound volume was set to by the user

<img width="408" height="494" src="https://github.com/user-attachments/assets/b8e5f557-a951-41ab-a9c4-402796296068" />