### PR TITLE
canvas focus & right click fixes

### DIFF
--- a/public/include/board.js
+++ b/public/include/board.js
@@ -296,7 +296,7 @@ const board = (function() {
         }
       }, { passive: true });
 
-      self.elements.zoomer.on('pointerdown mousedown', function() {
+      self.elements.container.on('pointerdown mousedown', function() {
         // unfocus whatever input boxes might be focused
         document.activeElement && typeof document.activeElement.blur === 'function' && document.activeElement.blur();
       }).contextmenu(function(evt) {

--- a/public/include/board.js
+++ b/public/include/board.js
@@ -296,6 +296,19 @@ const board = (function() {
         }
       }, { passive: true });
 
+      self.elements.zoomer.on('pointerdown mousedown', function() {
+        // unfocus whatever input boxes might be focused
+        document.activeElement && typeof document.activeElement.blur === 'function' && document.activeElement.blur();
+      }).contextmenu(function(evt) {
+        evt.preventDefault();
+        switch (settings.place.rightclick.action.get()) {
+          case 'clear':
+          case 'clearlookup':
+            place.switch(-1);
+            break;
+        }
+      });
+
       // now init the movement
       let downX, downY, downStart;
       self.elements.board_render.on('pointerdown mousedown', handleInputDown)

--- a/public/include/panels.js
+++ b/public/include/panels.js
@@ -100,6 +100,8 @@ module.exports.panels = (function() {
           document.body.classList.toggle(`panel-${panelPosition}`, true);
         } else {
           $(window).trigger('pxls:panel:closed', panelDescriptor);
+          // unfocus any active input boxes
+          document.activeElement && typeof document.activeElement.blur === 'function' && document.activeElement.blur();
           document.body.classList.toggle('panel-open', document.querySelectorAll('.panel.open').length - 1 > 0);
           document.body.classList.toggle(`panel-${panelPosition}`, false);
         }


### PR DESCRIPTION
this didn't seem like worth opening separate pull requests for.

this pull request:
- makes right-clicking on the canvas outside canvas bounds:
  - not open context menu
  - unfocus/blur the selected element to fix a bug where selects stay focused and pressing some keys (e.g. D for dotted and S for symbols if the template style select was focused) would cause them to switch to whatever options start with that letter
  - respect the clear selected color option
- makes closing panels unfocus/blur the selected element for same reason as above. this is more of a failsafe for when pressing B to close the settings panel