### PR TITLE
Remove Pxlsfiddle + misc

### DIFF
--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1206,8 +1206,8 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Why does it take so long to \"stack\" pixels?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
-msgstr "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgstr "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 
 #: /views/partials/faq.handlebars
 msgid "How do I appeal a ban?"
@@ -1246,8 +1246,8 @@ msgid "Where can I see the past canvases?"
 msgstr "Where can I see the past canvases?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
-msgstr "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
+msgstr "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 
 #: /views/partials/faq.handlebars
 msgid "How do I see who placed a pixel?"
@@ -1286,8 +1286,8 @@ msgid "How do I report bugs?"
 msgstr "How do I report bugs?"
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
-msgstr "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
+msgstr "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 
 #: /views/partials/faq.handlebars
 msgid "How do I get more info or contact staff?"

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1239,7 +1239,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr ""
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr ""
 
 #: /views/partials/faq.handlebars
@@ -1279,7 +1279,7 @@ msgid "Where can I see the past canvases?"
 msgstr ""
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr ""
 
 #: /views/partials/faq.handlebars
@@ -1319,7 +1319,7 @@ msgid "How do I report bugs?"
 msgstr ""
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr ""
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_bg.po
+++ b/po/Localization_bg.po
@@ -1206,7 +1206,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Защо отнема толкова дълго да се \"натрупат\" пиксели?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "Защото така е проектиран сайта. Натрупването е предназначено да подпомогне играчите, които са излезли офлайн за някакъв период от време. За натрупване на 6 пиксела трябва да се изчакат 30-40 минути, докато поставянето им веднага, след като таймера изтече би отнело под 3."
 
 #: /views/partials/faq.handlebars
@@ -1246,7 +1246,7 @@ msgid "Where can I see the past canvases?"
 msgstr "Къде мога да разгледам предишните платна?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "Последните кадри от предишните платна са включени на <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, а за пълен запис, посетете <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>."
 
 #: /views/partials/faq.handlebars
@@ -1286,7 +1286,7 @@ msgid "How do I report bugs?"
 msgstr "Как да докладвам за проблем?"
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr "Посетете канала #dev-and-bugs в <a href=\"https://pxls.space/discord\" target=\"_blank\">дискорд сървъра</a>."
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_de.po
+++ b/po/Localization_de.po
@@ -1213,7 +1213,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr ""
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr ""
 
 #: /views/partials/faq.handlebars
@@ -1253,7 +1253,7 @@ msgid "Where can I see the past canvases?"
 msgstr ""
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr ""
 
 #: /views/partials/faq.handlebars
@@ -1293,7 +1293,7 @@ msgid "How do I report bugs?"
 msgstr ""
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr ""
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_fi.po
+++ b/po/Localization_fi.po
@@ -1206,7 +1206,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Miksi pikselien \"pinoaminen\" kestää niin kauan?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "Tämä on taroituksellista. On parempi asetta pikseli heti kun saat yhden. Pikselien \"pinoamisen\" tarkoitus antaa tönäisy jos menet AFK vähäksi aikaa. Täyden 6/6 pikseliä pinon saaminen kestää noin 40 minuuttia, mutta voit asettaa 6 pikseliä vain noin 3:ssa minuutissa jos asetat ne niin pian kuin mahdollista."
 
 #: /views/partials/faq.handlebars
@@ -1246,7 +1246,7 @@ msgid "Where can I see the past canvases?"
 msgstr "Missä voin nähdä aikaissemmat kanvaasit?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "Aikaisemmat kanvaasit ovat esillä <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord serverillämme</a>, tai 3. osapuolen sivustolla <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, joka tallentaa timelapseja ja paljon hyödyllistä informaatiota jokaisesta kanvaasista."
 
 #: /views/partials/faq.handlebars
@@ -1286,7 +1286,7 @@ msgid "How do I report bugs?"
 msgstr "Kuinka raportoin bugeista?"
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr "Lähetä bugit #dev-and-bugs -kanavalle <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord serverillä</a>.Jos olet löytänyt exploitin, ole hyvä ja lähetä viesti yhdelle henkilökuntamme jäsenistä yksityisesti (DM:ien kautta)."
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1244,7 +1244,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Pourquoi ça prends si longtemps à avoir sa réserve de pixel pleine ?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "C'est une question de conception. Il est préférable de poser un pixel dès que vous en avez. La réserve a pour but de vous donner un coup de pouce si vous restez AFK. Cela prends environ 40 minutes pour avoir la réserve pleine (6/6), mais seulement 3 minutes si vous les placer dès que possible."
 
 #: /views/partials/faq.handlebars
@@ -1284,7 +1284,7 @@ msgid "Where can I see the past canvases?"
 msgstr "Où puis-je voir les canvas passés ?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "Les anciens canvas sont mis en avant sur notre <a href=\"https://pxls.space/discord\" target=\"_blank\">serveur Discord</a> ou sur le site externe <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, qui enregistre des timelapses et bien d'autres informations utiles sur chaque canvas."
 
 #: /views/partials/faq.handlebars
@@ -1324,7 +1324,7 @@ msgid "How do I report bugs?"
 msgstr "Comment signaler un bug ?"
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr "Envoyer vos trouvailles dans le salon #dev-and-bugs sur notre <a href=\"https://pxls.space/discord\" target=\"_blank\">serveur Discord</a>. Si vous avez trouver une faille, merci de contacter en priver l'un des staffs (via les MPs)."
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_lv.po
+++ b/po/Localization_lv.po
@@ -1215,7 +1215,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Kāpēc tas aizņem tik ilgi sakrāt vairākus pikseļus?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "Tā ir domāts. Ir ātrāk nolikt pikseli uzreiz, kad tas ir pieejams. Pikseļu krāšana ir domāta, lai iedotu jums nelielu bonusu pēc tā, ka pārstājat likt. Iegūt pilnus 6/6 pikseļus aizņem 40 minūtes, bet ja tos likt uzreiz, 6 pikseļi aizņemtu tikai 3 minūtes."
 
 #: /views/partials/faq.handlebars
@@ -1255,7 +1255,7 @@ msgid "Where can I see the past canvases?"
 msgstr "Kur es varu redzēt pagājušās kanvas?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "Pagājušās kanvas ir parādītas mūsu <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord serverī</a>, vai trešās puses mājaslapā <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, kas ieraksta video un daudz noderīgas informācijas par katru kanvu."
 
 #: /views/partials/faq.handlebars
@@ -1296,7 +1296,7 @@ msgstr "Kā man paziņot par kļūdu?"
 
 # I can't think of a way to say staff without sounding super weird
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr "Par kļūdām varat paziņot #dev-and-bugs kanālā mūsu <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord serverī</a>. Ja atradāt eksploitu, lūdzu sazinieties ar administratoru privātā sarakstē."
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_ru.po
+++ b/po/Localization_ru.po
@@ -1206,7 +1206,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Почему так долго накапливаются пиксели?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "Это сделано намеренно. Лучше разместить пиксель, как только вы его получите. Накопление пикселей должно дать вам толчок, если вы отошли на некоторое время и вернулись. Чтобы получить полные 6/6 пикселей, требуется около 40 минут, но для размещения 6 пикселей, по отдельности без накопления, требуется всего около 3 минут."
 
 #: /views/partials/faq.handlebars
@@ -1246,7 +1246,7 @@ msgid "Where can I see the past canvases?"
 msgstr "Где я могу увидеть прошлые полотна?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "Прошлые полотна представлены на нашем сайте, <a href=\"https://pxls.space/discord\" target=\"_blank\">Дискорде</a>, или на стороннем веб-сайте <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, который записывает таймлапсы и много полезной информации по каждому полотну."
 
 #: /views/partials/faq.handlebars
@@ -1286,7 +1286,7 @@ msgid "How do I report bugs?"
 msgstr "Как мне сообщить о багах (ошибках) сайта?"
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
 msgstr "Отправляйте сообщения об багах в #dev-and-bugs канал в <a href=\"https://pxls.space/discord\" target=\"_blank\">Дискорде</a>. Если вы обнаружили эксплойт, сообщите об этом одному из модераторов/администраторов в частном порядке (через личные сообщения в Дискорде)."
 
 #: /views/partials/faq.handlebars

--- a/po/Localization_sv.po
+++ b/po/Localization_sv.po
@@ -1212,7 +1212,7 @@ msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Varför tar det en så long tid att \"stapla\" pixlar?"
 
 #: /views/partials/faq.handlebars
-msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
+msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "Det är designat så här. Det är bättre att placera en pixel så fort du får den. Pixel \"staplande\" är mer för dom som går AFK. Det tar runt 40 minuter för att få 6/6 pixlar, medans det bara tar runt 3 minuter för att placera lika många om man gör det så fort man får dom."
 
 #: /views/partials/faq.handlebars
@@ -1252,7 +1252,7 @@ msgid "Where can I see the past canvases?"
 msgstr "Vart kan jag se dom föredetta kanvaserna?"
 
 #: /views/partials/faq.handlebars
-msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
+msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the <a href=\"https://archives.pxls.space\" target=\"_blank\">archives</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "De föredetta kanvas är sparade på vår <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, och på tredje parti hemsidan <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, vilket sparar bilder av under kanvasen som sedan blir gjorda till en timelapse, och väldigt mycket information om kanvaserna."
 
 #: /views/partials/faq.handlebars
@@ -1292,8 +1292,8 @@ msgid "How do I report bugs?"
 msgstr "Hur kan jag raportera buggar?"
 
 #: /views/partials/faq.handlebars
-msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
-msgstr "Skicka in buggar till #dev-and-bugs kanalen i <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord servern</a>. Om du har hittat en själv-utnyttjande bugg, snälla meddela någon anställd privat (genom direkta meddelanden)."
+msgid "Submit bugs to the #dev-and-bugs forum in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384."
+msgstr "Skicka in buggar på #dev-and-bugs forumet i <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord servern</a>. Om du har hittat en så kallad exploit, meddela snälla någon anställd privat (genom direkta meddelanden) eller öppna en modmail genom att skicka ett medellande till pxls.mail#8384."
 
 #: /views/partials/faq.handlebars
 msgid "How do I get more info or contact staff?"

--- a/views/partials/faq.handlebars
+++ b/views/partials/faq.handlebars
@@ -9,7 +9,7 @@
             <dt>{{{i18n 'Why does it say 0/6 pixels?'}}}</dt>
             <dd>{{{i18n 'This means that you are waiting for your next pixel. When you place a pixel, there is a cooldown for when you can place the next one. Over time, you can gain up to 6 "stacked" pixels to place at once.'}}}</dd>
             <dt>{{{i18n 'Why does it take so long to "stack" pixels?'}}}</dt>
-            <dd>{{{i18n 'This is by design. It is better to place a pixel as soon as you get one. Pixel "stacking" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible.'}}}</dd>
+            <dd>{{{i18n 'This is by design. It is better to place a pixel as soon as you get one. Pixel "stacking" is meant to give you a bump if you go AFK for a bit. It takes around 20-30 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible.'}}}</dd>
             <dt>{{{i18n 'How do I appeal a ban?'}}}</dt>
             <dd>{{{i18n 'Contact us on <a href="https://pxls.space/discord" target="_blank">Discord</a> or send an appeal to our <a href="https://pxls.space/appeal" target="_blank">Google form</a> after reading the rules in the site\'s info panel.'}}}</dd>
             <dt>{{{i18n 'How do I make a template?'}}}</dt>
@@ -19,7 +19,7 @@
             <dt>{{{i18n 'Does the canvas reset? When?'}}}</dt>
             <dd>{{{i18n 'Yes. The canvas resets when it is completely full. A reset date is not usually decided until the canvas is full, but the average canvas life-span is around 1 month. Updates are posted in our <a href="https://pxls.space/discord" target="_blank">Discord server</a> when a reset date is set.'}}}</dd>
             <dt>{{{i18n 'Where can I see the past canvases?'}}}</dt>
-            <dd>{{{i18n 'The past canvases are featured on our <a href="https://pxls.space/discord" target="_blank">Discord server</a>, or the 3rd party website <a href="https://pxlsfiddle.com" target="_blank">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas.'}}}</dd>
+            <dd>{{{i18n 'The past canvases are featured on our <a href="https://pxls.space/discord" target="_blank">Discord server</a>, or the <a href="https://archives.pxls.space" target="_blank">archives</a>, which records timelapses and a lot of useful information on each canvas.'}}}</dd>
             <dt>{{{i18n 'How do I see who placed a pixel?'}}}</dt>
             <dd>{{{i18n 'By shift-clicking (or tap and hold on mobile) a pixel, you can see who placed a pixel, how many pixels they have placed, and when they placed it.'}}}</dd>
             <dt>{{{i18n 'How do I report someone?'}}}</dt>
@@ -29,7 +29,7 @@
             <dt>{{{i18n 'What is a "virginmap"?'}}}</dt>
             <dd>{{{i18n 'The virginmap shows which pixels have not yet been placed on (or “virgin” pixels).'}}}</dd>
             <dt>{{{i18n 'How do I report bugs?'}}}</dt>
-            <dd>{{{i18n 'Submit bugs to the #dev-and-bugs channel in the <a href="https://pxls.space/discord" target="_blank">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs).'}}}</dd>
+            <dd>{{{i18n 'Submit bugs to the #dev-and-bugs forum in the <a href="https://pxls.space/discord" target="_blank">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs) or open a modmail by DMing pxls.mail#8384.'}}}</dd>
             <dt>{{{i18n 'How do I get more info or contact staff?'}}}</dt>
             <dd>{{{i18n 'Check the info panel (the icon on the top left) for more details and links, or join our <a href="https://pxls.space/discord" target="_blank">Discord server</a>, where a staff member will gladly respond.'}}}</dd>
         </dl>

--- a/views/partials/info.handlebars
+++ b/views/partials/info.handlebars
@@ -79,6 +79,7 @@
         <ul>
             <li><a href="https://pxls.space/discord" target="_blank">{{{i18n 'Discord (main hub)'}}}</a></li>
             <li><a href="https://twitter.com/pxlsspace" target="_blank">{{{i18n 'Twitter'}}}</a></li>
+            <li><a href="https://bsky.app/profile/pxls.space" target="_blank">{{{i18n 'Bluesky'}}}</a></li>
             <li><a href="https://github.com/pxlsspace/Pxls" target="_blank">{{{i18n 'GitHub (back end)'}}}</a></li>
             <li><a href="https://github.com/pxlsspace/pxls-web" target="_blank">{{{i18n 'GitHub (front end)'}}}</a></li>
             {{! link to piskelapp.com }}
@@ -89,8 +90,6 @@
             <li><a href="https://pxls.space/profile" target="_blank">{{{i18n 'Profile (user info, factions, etc.)'}}}</a></li>
             <li><a href="https://wiki.pxls.space" target="_blank">{{{i18n 'Wiki'}}}</a></li>
             <li><a href="https://archives.pxls.space/" target="_blank" title="{{{i18n 'Archives'}}}">{{{i18n 'Archives'}}}</a></li>
-            {{! link to pxlsfiddle.com }}
-            <li><a href="https://pxlsfiddle.com/" target="_blank" title="{{{i18n 'Archives'}}}">{{{i18n 'PxlsFiddle (archives)'}}}</a></li>
         </ul>
     </div>
 </article>


### PR DESCRIPTION
o7 lil bro, you had a good round
I WOULD add links to fiddle.pxls.space but that seems far gone Additionally, the .pot file needs to be regenerated I think? Since I added the bluesky link in the info (but it should remain unchanged overall...)

Also changes some of the FAQ to line up with more modern information (modmail)